### PR TITLE
fix: update Goerli references to Sepolia

### DIFF
--- a/config/agent-local.yml
+++ b/config/agent-local.yml
@@ -314,12 +314,12 @@ didManager:
               rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
               gas: 1000001
               ttl: 31104001
-        did:ethr:goerli:
+        did:ethr:sepolia:
           $require: "@veramo/did-provider-ethr#EthrDIDProvider"
           $args:
             - defaultKms: local
-              network: goerli
-              rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+              network: sepolia
+              rpcUrl: https://sepolia.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
               gas: 1000001
               ttl: 31104001
         did:web:

--- a/config/agent.yml
+++ b/config/agent.yml
@@ -332,12 +332,12 @@ didManager:
               rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
               gas: 1000001
               ttl: 31104001
-        did:ethr:goerli:
+        did:ethr:sepolia:
           $require: "@veramo/did-provider-ethr#EthrDIDProvider"
           $args:
             - defaultKms: local
-              network: goerli
-              rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+              network: sepolia
+              rpcUrl: https://sepolia.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
               gas: 1000001
               ttl: 31104001
         did:web:


### PR DESCRIPTION
The project was using outdated references to the Goerli testnet, which has been deprecated with the Infura API. This commit updates these references to the Sepolia testnet to ensure the network functionality is not interrupted.